### PR TITLE
Comment by Maarten Balliauw on could-not-load-file-or-assembly-nuget-assembly-redirects

### DIFF
--- a/_data/comments/could-not-load-file-or-assembly-nuget-assembly-redirects/7e72514a.yml
+++ b/_data/comments/could-not-load-file-or-assembly-nuget-assembly-redirects/7e72514a.yml
@@ -1,0 +1,6 @@
+id: 7f28e328
+date: 2018-10-24T12:55:43.6617663Z
+name: Maarten Balliauw
+avatar: https://secure.gravatar.com/avatar/f62ebe822f6b351538e68cb2bbadefe9?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: True. This post predates `ProjectReferences` though (2014).


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/f62ebe822f6b351538e68cb2bbadefe9?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on could-not-load-file-or-assembly-nuget-assembly-redirects:**

True. This post predates `ProjectReferences` though (2014).