### PR TITLE
Comment by Winston Smith on could-not-load-file-or-assembly-nuget-assembly-redirects

### DIFF
--- a/_data/comments/could-not-load-file-or-assembly-nuget-assembly-redirects/70d70a9b.yml
+++ b/_data/comments/could-not-load-file-or-assembly-nuget-assembly-redirects/70d70a9b.yml
@@ -1,0 +1,5 @@
+id: 824282a8
+date: 2019-09-25T16:27:26.2506212Z
+name: Winston Smith
+avatar: https://secure.gravatar.com/avatar/00740959b42692bf9d85368b2e42eeb4?s=80&r=pg
+message: Please add a note at the very top that this does not work for _PackageReference_


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/00740959b42692bf9d85368b2e42eeb4?s=80&r=pg" width="64" height="64" />

**Comment by Winston Smith on could-not-load-file-or-assembly-nuget-assembly-redirects:**

Please add a note at the very top that this does not work for _PackageReference_