### PR TITLE
Comment by thargenediad on building-a-scheduled-cache-updater-in-aspnet-core-2

### DIFF
--- a/_data/comments/building-a-scheduled-cache-updater-in-aspnet-core-2/f1ff412f.yml
+++ b/_data/comments/building-a-scheduled-cache-updater-in-aspnet-core-2/f1ff412f.yml
@@ -1,0 +1,5 @@
+id: f2bdea9d
+date: 2019-10-03T18:12:31.9329662Z
+name: thargenediad
+avatar: https://secure.gravatar.com/avatar/f328e1e490283cfc22f41c819cb18efd?s=80&r=pg
+message: Is there a way to prevent the scheduled task from running on app start?  Currently, mine always runs at least once, during startup.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/f328e1e490283cfc22f41c819cb18efd?s=80&r=pg" width="64" height="64" />

**Comment by thargenediad on building-a-scheduled-cache-updater-in-aspnet-core-2:**

Is there a way to prevent the scheduled task from running on app start?  Currently, mine always runs at least once, during startup.