### PR TITLE
Comment by thargenediad on building-a-scheduled-cache-updater-in-aspnet-core-2

### DIFF
--- a/_data/comments/building-a-scheduled-cache-updater-in-aspnet-core-2/8161697d.yml
+++ b/_data/comments/building-a-scheduled-cache-updater-in-aspnet-core-2/8161697d.yml
@@ -1,0 +1,5 @@
+id: 81f0a243
+date: 2019-10-07T18:13:00.2104737Z
+name: thargenediad
+avatar: https://secure.gravatar.com/avatar/f328e1e490283cfc22f41c819cb18efd?s=80&r=pg
+message: Disregard.  I added a SchedulerHostedService.Initialize() method and an isInitialized flag, along with logic which will check the flag and initialize the SchedulerHostedService (if needed) without actually running the task.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/f328e1e490283cfc22f41c819cb18efd?s=80&r=pg" width="64" height="64" />

**Comment by thargenediad on building-a-scheduled-cache-updater-in-aspnet-core-2:**

Disregard.  I added a SchedulerHostedService.Initialize() method and an isInitialized flag, along with logic which will check the flag and initialize the SchedulerHostedService (if needed) without actually running the task.