### PR TITLE
Comment by Dan Mc on dont-use-azure-functions-as-a-web-application

### DIFF
--- a/_data/comments/dont-use-azure-functions-as-a-web-application/3739038d.yml
+++ b/_data/comments/dont-use-azure-functions-as-a-web-application/3739038d.yml
@@ -1,0 +1,10 @@
+id: 39ffab2b
+date: 2020-03-04T13:51:43.0701648Z
+name: Dan Mc
+avatar: https://secure.gravatar.com/avatar/92b331d075ee140f0d3f9ea3908f2ab9?s=80&r=pg
+message: >-
+  I've read this article 3 or 4 times to try and see the bit where you give a compelling reason as to why functions can't be used as a full API. I wholeheartedly agree 'things' should do one thing (not least functions), but single responsibility principle isn't mutually exclusive to API design.
+
+
+
+  Your article just says "don't", not sure I'm bothered enough about you "yelling" to avoid using functions for this.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/92b331d075ee140f0d3f9ea3908f2ab9?s=80&r=pg" width="64" height="64" />

**Comment by Dan Mc on dont-use-azure-functions-as-a-web-application:**

I've read this article 3 or 4 times to try and see the bit where you give a compelling reason as to why functions can't be used as a full API. I wholeheartedly agree 'things' should do one thing (not least functions), but single responsibility principle isn't mutually exclusive to API design.

Your article just says "don't", not sure I'm bothered enough about you "yelling" to avoid using functions for this.