### PR TITLE
Comment by A Ismaili on automatically-strong-name-signing-nuget-packages

### DIFF
--- a/_data/comments/automatically-strong-name-signing-nuget-packages/2f25641d.yml
+++ b/_data/comments/automatically-strong-name-signing-nuget-packages/2f25641d.yml
@@ -1,0 +1,18 @@
+id: 420103af
+date: 2020-04-08T15:37:57.8849149Z
+name: A Ismaili
+avatar: https://secure.gravatar.com/avatar/b695d362307a7c3a413edb38cfbdd763?s=80&r=pg
+url: www.featureadmin.com
+message: >+
+  I found also the following nuget package very useful, that takes care of signing every reference of a project during build. A build target for singing all reference is added automatically since the most recent version.
+
+  Nuget
+
+  https://www.nuget.org/packages/Brutal.Dev.StrongNameSigner/
+
+
+
+  Project
+
+  https://github.com/brutaldev/StrongNameSigner
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/b695d362307a7c3a413edb38cfbdd763?s=80&r=pg" width="64" height="64" />

**Comment by A Ismaili on automatically-strong-name-signing-nuget-packages:**

I found also the following nuget package very useful, that takes care of signing every reference of a project during build. A build target for singing all reference is added automatically since the most recent version.
Nuget
https://www.nuget.org/packages/Brutal.Dev.StrongNameSigner/

Project
https://github.com/brutaldev/StrongNameSigner
