### PR TITLE
Comment by TheBuzzSaw on deserializing-json-into-polymorphic-classes-with-systemtextjson

### DIFF
--- a/_data/comments/deserializing-json-into-polymorphic-classes-with-systemtextjson/85d9366c.yml
+++ b/_data/comments/deserializing-json-into-polymorphic-classes-with-systemtextjson/85d9366c.yml
@@ -1,0 +1,12 @@
+id: 86cbec0e
+date: 2020-07-25T18:14:36.9416104Z
+name: TheBuzzSaw
+email: 
+avatar: https://secure.gravatar.com/avatar/e4868b6d3075a52e98423a0ef0d8e111?s=80&r=pg
+url: 
+message: >-
+  > What’s nice is that Utf8JsonReader is a struct (allocated on the stack), so assigning it to a new variable essentially copies its state at that point. We will be able to deserialize the entire JSON object from that copy.
+
+
+
+  Are you absolutely certain that this is safe to do? The reader being a struct is largely done for performance reasons, but the docs clearly state this is a forward-only reader. Is there confirmation from any .NET internals devs that copying the reader and reading ahead is a safe operation?


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/e4868b6d3075a52e98423a0ef0d8e111?s=80&r=pg" width="64" height="64" />

**Comment by TheBuzzSaw on deserializing-json-into-polymorphic-classes-with-systemtextjson:**

> What’s nice is that Utf8JsonReader is a struct (allocated on the stack), so assigning it to a new variable essentially copies its state at that point. We will be able to deserialize the entire JSON object from that copy.

Are you absolutely certain that this is safe to do? The reader being a struct is largely done for performance reasons, but the docs clearly state this is a forward-only reader. Is there confirmation from any .NET internals devs that copying the reader and reading ahead is a safe operation?