### PR TITLE
Comment by Szymon Sandura on deserializing-json-into-polymorphic-classes-with-systemtextjson

### DIFF
--- a/_data/comments/deserializing-json-into-polymorphic-classes-with-systemtextjson/ad8ddd0f.yml
+++ b/_data/comments/deserializing-json-into-polymorphic-classes-with-systemtextjson/ad8ddd0f.yml
@@ -1,0 +1,16 @@
+id: aeef76b7
+date: 2021-04-28T14:48:42.5649259Z
+name: Szymon Sandura
+email: 
+avatar: https://secure.gravatar.com/avatar/a427f021ce6e9d52345d8f570a4b2a11?s=80&r=pg
+url: 
+message: >-
+  In order to stop infinite recursive calls you can either:
+
+  1. Stop passing 'options' variable inside JsonSerializer.(De)serialize() call.
+
+  2. Provide a fresh JsonSerializerOptions instance (useful for bringing back default behaviour such as PropertyNameCaseInsensitive = true or setting some custom stuff)
+
+
+
+  That way the Deserialization/Serialization calls won't be aware of any custom converters, be it registered by attributes or in startup file.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/a427f021ce6e9d52345d8f570a4b2a11?s=80&r=pg" width="64" height="64" />

**Comment by Szymon Sandura on deserializing-json-into-polymorphic-classes-with-systemtextjson:**

In order to stop infinite recursive calls you can either:
1. Stop passing 'options' variable inside JsonSerializer.(De)serialize() call.
2. Provide a fresh JsonSerializerOptions instance (useful for bringing back default behaviour such as PropertyNameCaseInsensitive = true or setting some custom stuff)

That way the Deserialization/Serialization calls won't be aware of any custom converters, be it registered by attributes or in startup file.