### PR TITLE
Comment by Marley on tracking-api-usage-with-google-analytics

### DIFF
--- a/_data/comments/tracking-api-usage-with-google-analytics/c51b12aa.yml
+++ b/_data/comments/tracking-api-usage-with-google-analytics/c51b12aa.yml
@@ -1,0 +1,12 @@
+id: d5fefefc
+date: 2021-07-16T09:07:51.9036598Z
+name: Marley
+email: 
+avatar: https://secure.gravatar.com/avatar/c6e72ee59ac24c6671da32567cab812a?s=80&r=pg
+url: N/A
+message: >-
+  Sessions are also untracked: every event that is tracked counts as a new unique visitor to Google Analytics.
+
+  If you do need to track user sessions, implement a custom IAnalyticsSession and pass it to the constructor of the tracker.
+
+  Looking for a sample code to implement custom IAnalyticsSession. Working on google analytics tracker, my problem is i would want to track users and sessions therefore at the moment every event tracked is counted as a unique user. I kindly need help on this, anyone?


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/c6e72ee59ac24c6671da32567cab812a?s=80&r=pg" width="64" height="64" />

**Comment by Marley on tracking-api-usage-with-google-analytics:**

Sessions are also untracked: every event that is tracked counts as a new unique visitor to Google Analytics.
If you do need to track user sessions, implement a custom IAnalyticsSession and pass it to the constructor of the tracker.
Looking for a sample code to implement custom IAnalyticsSession. Working on google analytics tracker, my problem is i would want to track users and sessions therefore at the moment every event tracked is counted as a unique user. I kindly need help on this, anyone?