### PR TITLE
Comment by jsek on making-api-calls-using-the-access-token-and-refresh-token-from-an-aspnet-core-authentication-handler

### DIFF
--- a/_data/comments/making-api-calls-using-the-access-token-and-refresh-token-from-an-aspnet-core-authentication-handler/03cd1a31.yml
+++ b/_data/comments/making-api-calls-using-the-access-token-and-refresh-token-from-an-aspnet-core-authentication-handler/03cd1a31.yml
@@ -1,0 +1,7 @@
+id: 04cff098
+date: 2021-07-29T17:59:52.5500731Z
+name: jsek
+email: 
+avatar: https://secure.gravatar.com/avatar/19f6556773de6ec99cb758892566b6a9?s=80&r=pg
+url: 
+message: Assuming these examples even work... How do you send Cookie back to the browser?


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/19f6556773de6ec99cb758892566b6a9?s=80&r=pg" width="64" height="64" />

**Comment by jsek on making-api-calls-using-the-access-token-and-refresh-token-from-an-aspnet-core-authentication-handler:**

Assuming these examples even work... How do you send Cookie back to the browser?