### PR TITLE
Comment by Maarten Balliauw on producer-consumer-pipelines-with-system-threading-channels

### DIFF
--- a/_data/comments/producer-consumer-pipelines-with-system-threading-channels/1a267d16.yml
+++ b/_data/comments/producer-consumer-pipelines-with-system-threading-channels/1a267d16.yml
@@ -1,0 +1,9 @@
+id: 1af92253
+date: 2021-09-20T08:00:49.5986644Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: >+
+  You can also fan out in multiple pipelines. E.g. one fast producer populates multiple other pipelines in the last step.
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on producer-consumer-pipelines-with-system-threading-channels:**

You can also fan out in multiple pipelines. E.g. one fast producer populates multiple other pipelines in the last step.
