### PR TITLE
Comment by Brandon Butler on run-azurite-in-docker-with-rider-and-keep-azure-storage-data-local-to-a-solution

### DIFF
--- a/_data/comments/run-azurite-in-docker-with-rider-and-keep-azure-storage-data-local-to-a-solution/210da796.yml
+++ b/_data/comments/run-azurite-in-docker-with-rider-and-keep-azure-storage-data-local-to-a-solution/210da796.yml
@@ -1,0 +1,7 @@
+id: 21e3fedd
+date: 2022-03-25T14:51:32.6037696Z
+name: Brandon Butler
+email: 
+avatar: https://secure.gravatar.com/avatar/f616901b59e1760db512d20e248096d8?s=80&r=pg
+url: 
+message: Rider can actually run azurite itself. https://blog.jetbrains.com/dotnet/2020/08/27/azurite-support-timer-trigger-code-completion-and-more-azure-toolkit-for-rider-2020-2-updates/


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/f616901b59e1760db512d20e248096d8?s=80&r=pg" width="64" height="64" />

**Comment by Brandon Butler on run-azurite-in-docker-with-rider-and-keep-azure-storage-data-local-to-a-solution:**

Rider can actually run azurite itself. https://blog.jetbrains.com/dotnet/2020/08/27/azurite-support-timer-trigger-code-completion-and-more-azure-toolkit-for-rider-2020-2-updates/