### PR TITLE
Comment by Maarten Balliauw on nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1

### DIFF
--- a/_data/comments/nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1/ce14ffc2.yml
+++ b/_data/comments/nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1/ce14ffc2.yml
@@ -1,0 +1,12 @@
+id: bef99670
+date: 2022-04-22T05:24:16.8865501Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: >-
+  @Luiz everything from 3.1 and especially 5.0 and up is mostly annotated. ASP.NET has good annotations, and EF Core even uses them to determine database properties (I'll talk about that in part 4, as it has pros and cons)
+
+
+
+  You can gradually start adopting it in your own code if you're on any of the newer framework versions.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1:**

@Luiz everything from 3.1 and especially 5.0 and up is mostly annotated. ASP.NET has good annotations, and EF Core even uses them to determine database properties (I'll talk about that in part 4, as it has pros and cons)

You can gradually start adopting it in your own code if you're on any of the newer framework versions.