### PR TITLE
Comment by Luiz Bicalho on nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1

### DIFF
--- a/_data/comments/nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1/e49588bf.yml
+++ b/_data/comments/nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1/e49588bf.yml
@@ -1,0 +1,7 @@
+id: e5f5ac32
+date: 2022-04-25T13:18:20.4240732Z
+name: Luiz Bicalho
+email: 
+avatar: https://secure.gravatar.com/avatar/6673c5d48af60dd93f0f1058ca3b0b03?s=80&r=pg
+url: 
+message: Thanks @Maarten, last time I looked the ASP.NET Identity core https://www.nuget.org/packages/Microsoft.AspNet.Identity.Core/ wasn't updated yet, and I use it in my libraries.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/6673c5d48af60dd93f0f1058ca3b0b03?s=80&r=pg" width="64" height="64" />

**Comment by Luiz Bicalho on nullable-reference-types-in-csharp-migrating-to-nullable-reference-types-part-1:**

Thanks @Maarten, last time I looked the ASP.NET Identity core https://www.nuget.org/packages/Microsoft.AspNet.Identity.Core/ wasn't updated yet, and I use it in my libraries.