### PR TITLE
Comment by ben on annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3

### DIFF
--- a/_data/comments/annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3/6f56922b.yml
+++ b/_data/comments/annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3/6f56922b.yml
@@ -1,0 +1,16 @@
+id: 70427365
+date: 2022-04-26T16:50:01.6083588Z
+name: ben
+email: 
+avatar: https://secure.gravatar.com/avatar/d9c76556651ac647c8524464198eb618?s=80&r=pg
+url: 
+message: >-
+  Thanks for a great series about what turns out to be a complex topic.
+
+
+
+  You said "even with nullable reference types enabled, you still need to do null checks on untrusted and/or external input."
+
+
+
+  That's certainly true. Do you think it is also a good policy to mark these untrusted input parameters as explicitly nullable? This will ensure that the compiler warns me if i modify the code later and accidentally remove the null check.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/d9c76556651ac647c8524464198eb618?s=80&r=pg" width="64" height="64" />

**Comment by ben on annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3:**

Thanks for a great series about what turns out to be a complex topic.

You said "even with nullable reference types enabled, you still need to do null checks on untrusted and/or external input."

That's certainly true. Do you think it is also a good policy to mark these untrusted input parameters as explicitly nullable? This will ensure that the compiler warns me if i modify the code later and accidentally remove the null check.