### PR TITLE
Comment by Maarten Balliauw on annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3

### DIFF
--- a/_data/comments/annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3/1d9c8a46.yml
+++ b/_data/comments/annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3/1d9c8a46.yml
@@ -1,0 +1,7 @@
+id: 1eab3dee
+date: 2022-04-29T08:12:05.2728879Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: "Forgot to add: I'll give an example in part 4 that may be useful in these cases, where both consumers and authors of the method get some assistance."


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on annotating-your-csharp-code-migrating-to-nullable-reference-types-part-3:**

Forgot to add: I'll give an example in part 4 that may be useful in these cases, where both consumers and authors of the method get some assistance.