### PR TITLE
Comment by Grigory on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4

### DIFF
--- a/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/2c3a7202.yml
+++ b/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/2c3a7202.yml
@@ -1,0 +1,33 @@
+id: 2ed1bb2d
+date: 2022-08-10T06:19:07.2064378Z
+name: Grigory
+email: 
+avatar: https://secure.gravatar.com/avatar/42ab54e6c113d448fbed739afaa84eb3?s=80&r=pg
+url: 
+message: >+
+  Thank you for the great articles.
+
+  However, I'm a bit confused with the point:
+
+  >>Add a default value and suppress the warning - Bad!
+
+
+
+  At the end of the article you mentioned Entity Framework. When you set up your DbContext you have a list of DbSets. E.g. in my case it looks something like this:
+
+      public DbSet<StyleDbModel> Styles { get; init; } = null!
+
+      public DbSet<ColorDbModel> Colors { get; init; } = null!
+
+      public DbSet<CategoryDbModel> Categories { get; init; } = null!
+
+
+
+  As you can see I lie to the compiler, and I don't see a better way to do it here. DbSets always will be not null, because that is how EF works.
+
+  Or maybe I miss something and you know the better approach?
+
+
+
+
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/42ab54e6c113d448fbed739afaa84eb3?s=80&r=pg" width="64" height="64" />

**Comment by Grigory on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4:**

Thank you for the great articles.
However, I'm a bit confused with the point:
>>Add a default value and suppress the warning - Bad!

At the end of the article you mentioned Entity Framework. When you set up your DbContext you have a list of DbSets. E.g. in my case it looks something like this:
    public DbSet<StyleDbModel> Styles { get; init; } = null!
    public DbSet<ColorDbModel> Colors { get; init; } = null!
    public DbSet<CategoryDbModel> Categories { get; init; } = null!

As you can see I lie to the compiler, and I don't see a better way to do it here. DbSets always will be not null, because that is how EF works.
Or maybe I miss something and you know the better approach?


