### PR TITLE
Comment by Maarten Balliauw on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4

### DIFF
--- a/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/9d60a529.yml
+++ b/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/9d60a529.yml
@@ -1,0 +1,9 @@
+id: 9e696714
+date: 2022-08-12T06:16:48.5404828Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: >+
+  That's definitely lying to the compiler, but alas, no other way around it in this case. I would say in this case it is fine. You could disable/enable nullability for those properties as well (using `#nullable disable / enable`.
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4:**

That's definitely lying to the compiler, but alas, no other way around it in this case. I would say in this case it is fine. You could disable/enable nullability for those properties as well (using `#nullable disable / enable`.
