### PR TITLE
Comment by Doug Waldron on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4

### DIFF
--- a/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/142f0a3e.yml
+++ b/_data/comments/techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4/142f0a3e.yml
@@ -1,0 +1,22 @@
+id: 15402f0f
+date: 2022-09-19T19:28:03.5391946Z
+name: Doug Waldron
+email: 
+avatar: https://secure.gravatar.com/avatar/2ad66d2aa252b8f4e095a2235dcfb895?s=80&r=pg
+url: 
+message: >-
+  @Grigory The [Entity Framework docs](https://learn.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types#dbcontext-and-dbset) address your question. If you don't want to use the null-forgiving operator, you can alternately use this syntax:
+
+
+
+  ```
+
+      public DbSet<Customer> Customers => Set<Customer>();
+
+      public DbSet<Order> Orders => Set<Order>();
+
+  ```
+
+
+
+  Hope that helps!


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/2ad66d2aa252b8f4e095a2235dcfb895?s=80&r=pg" width="64" height="64" />

**Comment by Doug Waldron on techniques-and-tools-to-update-your-csharp-project-migrating-to-nullable-reference-types-part-4:**

@Grigory The [Entity Framework docs](https://learn.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types#dbcontext-and-dbset) address your question. If you don't want to use the null-forgiving operator, you can alternately use this syntax:

```
    public DbSet<Customer> Customers => Set<Customer>();
    public DbSet<Order> Orders => Set<Order>();
```

Hope that helps!