### PR TITLE
Comment by Maarten Balliauw on aspnet-core-rate-limiting-middleware

### DIFF
--- a/_data/comments/aspnet-core-rate-limiting-middleware/c26e7976.yml
+++ b/_data/comments/aspnet-core-rate-limiting-middleware/c26e7976.yml
@@ -1,0 +1,12 @@
+id: c35c4e32
+date: 2022-10-01T18:08:19.2667191Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: >-
+  For the statistics, do give this issue a +1 - https://github.com/dotnet/aspnetcore/issues/44140
+
+
+
+  Storage is indeed always in memory, the framework doesn't have anything out of the box there (and not easily pluggable).


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on aspnet-core-rate-limiting-middleware:**

For the statistics, do give this issue a +1 - https://github.com/dotnet/aspnetcore/issues/44140

Storage is indeed always in memory, the framework doesn't have anything out of the box there (and not easily pluggable).