### PR TITLE
Comment by JeeWee@mastodon.social on mastodon-own-donain-without-hosting-server

### DIFF
--- a/_data/comments/mastodon-own-donain-without-hosting-server/eef78f19.yml
+++ b/_data/comments/mastodon-own-donain-without-hosting-server/eef78f19.yml
@@ -1,0 +1,7 @@
+id: efc1a35b
+date: 2022-11-26T09:24:01.3083634Z
+name: JeeWee@mastodon.social
+email: 
+avatar: https://secure.gravatar.com/avatar/f2f8c7840596a65a939406a12b563ed2?s=80&r=pg
+url: 
+message: I get an error (503Remote SSL certificate could not be verified) when I search for @maarten@balliauw.be from my account at mastodon.social


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/f2f8c7840596a65a939406a12b563ed2?s=80&r=pg" width="64" height="64" />

**Comment by JeeWee@mastodon.social on mastodon-own-donain-without-hosting-server:**

I get an error (503Remote SSL certificate could not be verified) when I search for @maarten@balliauw.be from my account at mastodon.social