### PR TITLE
Comment by Alexander Krivacs Schrøder on mastodon-own-donain-without-hosting-server

### DIFF
--- a/_data/comments/mastodon-own-donain-without-hosting-server/f6856ad8.yml
+++ b/_data/comments/mastodon-own-donain-without-hosting-server/f6856ad8.yml
@@ -1,0 +1,7 @@
+id: f77c63d9
+date: 2022-12-05T05:37:56.8775631Z
+name: Alexander Krivacs Schrøder
+email: 
+avatar: https://secure.gravatar.com/avatar/74b00bbfe9ba0f647bb154ed5f923cb4?s=80&r=pg
+url: https://alexanderschroeder.net/
+message: "@maarten@balliauw.be doesn't seem to be working on account of balliauw.be being misconfigured. Also, I couldn't use the \"join the discussion\" box to write my comment here; had to manually make the \"message\" input visible and type it there instead."


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/74b00bbfe9ba0f647bb154ed5f923cb4?s=80&r=pg" width="64" height="64" />

**Comment by Alexander Krivacs Schrøder on mastodon-own-donain-without-hosting-server:**

@maarten@balliauw.be doesn't seem to be working on account of balliauw.be being misconfigured. Also, I couldn't use the "join the discussion" box to write my comment here; had to manually make the "message" input visible and type it there instead.