### PR TITLE
Comment by Scott DeToffol on mastodon-own-donain-without-hosting-server

### DIFF
--- a/_data/comments/mastodon-own-donain-without-hosting-server/761a93f9.yml
+++ b/_data/comments/mastodon-own-donain-without-hosting-server/761a93f9.yml
@@ -1,0 +1,7 @@
+id: 7887ea8f
+date: 2022-12-05T18:00:00.5296155Z
+name: Scott DeToffol
+email: 
+avatar: https://secure.gravatar.com/avatar/6e907b84a882bf57a37c4cb6a2876ee3?s=80&r=pg
+url: http://detoffol.com/
+message: "Thanks for the tip, but I'm unable to get the following error: https://webfinger.net/lookup/?resource=https%3A%2F%2Fdetoffol.com \r\n\r\n\"Error getting JRD: invalid content-type: \"\r\n\r\nAny ideas?\r\n\r\nhttps://detoffol.com/.well-known/webfinger\r\n"


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/6e907b84a882bf57a37c4cb6a2876ee3?s=80&r=pg" width="64" height="64" />

**Comment by Scott DeToffol on mastodon-own-donain-without-hosting-server:**

Thanks for the tip, but I'm unable to get the following error: https://webfinger.net/lookup/?resource=https%3A%2F%2Fdetoffol.com 

"Error getting JRD: invalid content-type: "

Any ideas?

https://detoffol.com/.well-known/webfinger
