### PR TITLE
Comment by Christophe R Patraldo on mastodon-own-donain-without-hosting-server

### DIFF
--- a/_data/comments/mastodon-own-donain-without-hosting-server/c30fcc35.yml
+++ b/_data/comments/mastodon-own-donain-without-hosting-server/c30fcc35.yml
@@ -1,0 +1,12 @@
+id: c4147396
+date: 2022-12-07T18:02:36.8186007Z
+name: Christophe R Patraldo
+email: 
+avatar: https://secure.gravatar.com/avatar/1d20252c70e07da8e75e574e6cf2434a?s=80&r=pg
+url: https://patraldo.dev/
+message: >-
+  Thanks for this - It works!  check it out: @mxurbano@happyhobbit.dev and it should take you to @mxurbano@mastodon.mexicanbold.com.  Wow!  That's really cool.  Thanks again!
+
+
+
+  Meanwhile, if I put @maarten@balliauw.be in the search bar in Mastodon, I get: 503Remote SSL certificate could not be verified


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/1d20252c70e07da8e75e574e6cf2434a?s=80&r=pg" width="64" height="64" />

**Comment by Christophe R Patraldo on mastodon-own-donain-without-hosting-server:**

Thanks for this - It works!  check it out: @mxurbano@happyhobbit.dev and it should take you to @mxurbano@mastodon.mexicanbold.com.  Wow!  That's really cool.  Thanks again!

Meanwhile, if I put @maarten@balliauw.be in the search bar in Mastodon, I get: 503Remote SSL certificate could not be verified