### PR TITLE
Comment by Jack on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp

### DIFF
--- a/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/39418362.yml
+++ b/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/39418362.yml
@@ -1,0 +1,7 @@
+id: 4ab346a4
+date: 2023-01-16T11:52:48.0108708Z
+name: Jack
+email: 
+avatar: https://secure.gravatar.com/avatar/0dae306a516128af3a7fb7ba9c4def28?s=80&r=pg
+url: https://jtbrown.me/
+message: I like to handle this scenario by using a naming convention + adding a pattern match rule into .editorconfig so that we don't get warnings on these types of records


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/0dae306a516128af3a7fb7ba9c4def28?s=80&r=pg" width="64" height="64" />

**Comment by Jack on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp:**

I like to handle this scenario by using a naming convention + adding a pattern match rule into .editorconfig so that we don't get warnings on these types of records