### PR TITLE
Comment by Mattias Nordqvist on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp

### DIFF
--- a/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/aef64db1.yml
+++ b/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/aef64db1.yml
@@ -1,0 +1,7 @@
+id: afc88f28
+date: 2023-04-01T05:32:35.1382410Z
+name: Mattias Nordqvist
+email: 
+avatar: https://secure.gravatar.com/avatar/280b54e18d8b9e4b08428676374f56d0?s=80&r=pg
+url: 
+message: How is option 5 different from 2 except for the fact that it is more expressive? The default value will still be null when deserializing, right?


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/280b54e18d8b9e4b08428676374f56d0?s=80&r=pg" width="64" height="64" />

**Comment by Mattias Nordqvist on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp:**

How is option 5 different from 2 except for the fact that it is more expressive? The default value will still be null when deserializing, right?