### PR TITLE
Comment by Maarten Balliauw on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp

### DIFF
--- a/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/3dea043e.yml
+++ b/_data/comments/getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp/3dea043e.yml
@@ -1,0 +1,7 @@
+id: 3ecce152
+date: 2023-04-03T05:14:14.8957886Z
+name: Maarten Balliauw
+email: 
+avatar: https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg
+url: https://blog.maartenballiauw.be/
+message: Correct. This is assuming the C# code and JSON are both correctly annotated/generated, and the JSON never contains a `null` where the POCO says otherwise.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/112c461046c64635060557a5a566d6a4?s=80&r=pg" width="64" height="64" />

**Comment by Maarten Balliauw on getting-rid-of-warnings-with-nullable-reference-types-and-json-object-models-in-csharp:**

Correct. This is assuming the C# code and JSON are both correctly annotated/generated, and the JSON never contains a `null` where the POCO says otherwise.