### PR TITLE
Comment by Séraphin on mastodon-own-donain-without-hosting-server

### DIFF
--- a/_data/comments/mastodon-own-donain-without-hosting-server/af224708.yml
+++ b/_data/comments/mastodon-own-donain-without-hosting-server/af224708.yml
@@ -1,0 +1,7 @@
+id: 9ff7ab5a
+date: 2023-04-29T10:53:03.7660320Z
+name: Séraphin
+email: 
+avatar: https://secure.gravatar.com/avatar/c889906d01935bec07369dd8e5f08453?s=80&r=pg
+url: https://aynils.ca/
+message: 'Thank you for sharing! BTW, the form is not working on Firefox. I had to change the tag of the #comment-div from div to input to be able to enter text.'


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/c889906d01935bec07369dd8e5f08453?s=80&r=pg" width="64" height="64" />

**Comment by Séraphin on mastodon-own-donain-without-hosting-server:**

Thank you for sharing! BTW, the form is not working on Firefox. I had to change the tag of the #comment-div from div to input to be able to enter text.