### PR TITLE
Comment by PsillyPseudonym on running-large-language-models-locally-your-own-chatgpt-like-ai-in-csharp

### DIFF
--- a/_data/comments/running-large-language-models-locally-your-own-chatgpt-like-ai-in-csharp/e171ec43.yml
+++ b/_data/comments/running-large-language-models-locally-your-own-chatgpt-like-ai-in-csharp/e171ec43.yml
@@ -1,0 +1,17 @@
+id: e23e324a
+date: 2023-07-05T22:11:47.7013964Z
+name: PsillyPseudonym
+email: 
+avatar: https://secure.gravatar.com/avatar/d4c26a129974d1407283b6cbf7431b06?s=80&r=pg
+url: 
+message: >+
+  Thanks for this tutorial!
+
+
+
+  I couldn't find a clear answer to this question:
+
+  Can you use LLamaSharp in .NetFramwork applications? The example they have on github works fine in a .NetCore application but when I try it in .Netframework, I get the error:
+
+  “System.TypeInitializationException: 'The type initializer for 'LLama.Native.NativeApi' threw an exception.' RuntimeError: The native library cannot be found.”
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/d4c26a129974d1407283b6cbf7431b06?s=80&r=pg" width="64" height="64" />

**Comment by PsillyPseudonym on running-large-language-models-locally-your-own-chatgpt-like-ai-in-csharp:**

Thanks for this tutorial!

I couldn't find a clear answer to this question:
Can you use LLamaSharp in .NetFramwork applications? The example they have on github works fine in a .NetCore application but when I try it in .Netframework, I get the error:
“System.TypeInitializationException: 'The type initializer for 'LLama.Native.NativeApi' threw an exception.' RuntimeError: The native library cannot be found.”
