### PR TITLE
Comment by muhsin on discriminated-unions-in-csharp

### DIFF
--- a/_data/comments/discriminated-unions-in-csharp/c2a09764.yml
+++ b/_data/comments/discriminated-unions-in-csharp/c2a09764.yml
@@ -1,0 +1,7 @@
+id: c3ff7a4d
+date: 2023-10-07T05:16:52.1909953Z
+name: muhsin
+email: 
+avatar: https://secure.gravatar.com/avatar/0d7eea1a955c24a40c56930cbc5fce07?s=80&r=pg
+url: 
+message: Discriminated unions specify pre-defined types for data, enabling precise type information for the compiler and IDE, preventing unintended type mismatches and enhancing <a href="https://www.britishherald.com/">API result clarity.</a>


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/0d7eea1a955c24a40c56930cbc5fce07?s=80&r=pg" width="64" height="64" />

**Comment by muhsin on discriminated-unions-in-csharp:**

Discriminated unions specify pre-defined types for data, enabling precise type information for the compiler and IDE, preventing unintended type mismatches and enhancing <a href="https://www.britishherald.com/">API result clarity.</a>