### PR TITLE
Comment by GhostlyShade on test-driving-windows-11-dev-drive-for-dotnet

### DIFF
--- a/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/3e66f586.yml
+++ b/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/3e66f586.yml
@@ -1,0 +1,12 @@
+id: 3f9854e7
+date: 2023-11-23T11:02:24.8632979Z
+name: GhostlyShade
+email: 
+avatar: https://secure.gravatar.com/avatar/eb5a970dee90b43192bf219cc2c882c8?s=80&r=pg
+url: 
+message: >-
+  it seems that if you move the nuget cache to the dev drive, local dotnet tool does not work anymore.
+
+  example, if you run "dotnet tool install gitversion.tool" and try to run "dotnet tool run dotnet-gitversion", it won't find the tool and ask you to install it again.
+
+  There is an open issue on the dotnet sdk repo: https://github.com/dotnet/sdk/issues/15306


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/eb5a970dee90b43192bf219cc2c882c8?s=80&r=pg" width="64" height="64" />

**Comment by GhostlyShade on test-driving-windows-11-dev-drive-for-dotnet:**

it seems that if you move the nuget cache to the dev drive, local dotnet tool does not work anymore.
example, if you run "dotnet tool install gitversion.tool" and try to run "dotnet tool run dotnet-gitversion", it won't find the tool and ask you to install it again.
There is an open issue on the dotnet sdk repo: https://github.com/dotnet/sdk/issues/15306