### PR TITLE
Comment by Andreas Gullberg Larsen on test-driving-windows-11-dev-drive-for-dotnet

### DIFF
--- a/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/c48dd79a.yml
+++ b/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/c48dd79a.yml
@@ -1,0 +1,31 @@
+id: c58ab535
+date: 2023-12-12T08:02:06.2240461Z
+name: Andreas Gullberg Larsen
+email: 
+avatar: https://secure.gravatar.com/avatar/4166c32037bc43de02f2322e59320b4a?s=80&r=pg
+url: 
+message: >+
+  Great writeup and you made we want to try this myself!
+
+
+  But for me it was weird. 
+
+  I just tried it on a laptop with Win11 with bitlocker enabled, and saw a slowdown using DevDrive.
+
+
+  Ran this on a fairly big solution with 100 projects, timing only the build phase:
+
+  dotnet clean && dotnet restore && time dotnet build
+
+
+  Repeated test 4 times:
+
+  1. Regular folder c:\dev, excluded from anti-virus - 4 x 14-15 seconds fairly stable
+
+  2. Windrive folder c:\devdrive (not excluded from anti-virus) via VHDX file on same drive - 2 x 15 seconds, 2 x 30 seconds
+
+
+  I'll test more, it could be a power profile or thermal dethrottling or something, but initial tests were discouraging. Also not sure if it is better to do a full partition for DevDrive or if VHDX should perform equally well.
+
+
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/4166c32037bc43de02f2322e59320b4a?s=80&r=pg" width="64" height="64" />

**Comment by Andreas Gullberg Larsen on test-driving-windows-11-dev-drive-for-dotnet:**

Great writeup and you made we want to try this myself!

But for me it was weird. 
I just tried it on a laptop with Win11 with bitlocker enabled, and saw a slowdown using DevDrive.

Ran this on a fairly big solution with 100 projects, timing only the build phase:
dotnet clean && dotnet restore && time dotnet build

Repeated test 4 times:
1. Regular folder c:\dev, excluded from anti-virus - 4 x 14-15 seconds fairly stable
2. Windrive folder c:\devdrive (not excluded from anti-virus) via VHDX file on same drive - 2 x 15 seconds, 2 x 30 seconds

I'll test more, it could be a power profile or thermal dethrottling or something, but initial tests were discouraging. Also not sure if it is better to do a full partition for DevDrive or if VHDX should perform equally well.



