### PR TITLE
Comment by Ben van der Stouwe on test-driving-windows-11-dev-drive-for-dotnet

### DIFF
--- a/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/1945ec03.yml
+++ b/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/1945ec03.yml
@@ -1,0 +1,23 @@
+id: 1a4836d5
+date: 2024-01-25T11:01:30.9828873Z
+name: Ben van der Stouwe
+email: 
+avatar: https://secure.gravatar.com/avatar/d36af180ebe6d314a00d0c1dd0ad8ca6?s=80&r=pg
+url: https://twitter.com/benvdstouwe
+message: >+
+  Hi Maarten,
+
+
+  Thanks for the post! I was able to setup my Dev Drive using this.
+
+
+  I think you have a bug in your PowerShell script to move package folders. You're moving the `npm-cache*` folders with the Move-Item command but you're setting the environment variable to `npm_cache`. I believe NPM won't use the moved cached packages because of this and will resolve them in the configured directory. 
+
+
+  Also, the "remove all bin and obj folders" command also removed ObjectExtensions classes in my case. Changing the `bin,obj*` to `bin,obj` still removed all bin and obj folders but did not remove the ObjectExtensions classes.
+
+
+  And slightly off-topic, I was not able to type a comment on this page while in Firefox. It's working on Edge. 
+
+
+  Keep up the good work!


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/d36af180ebe6d314a00d0c1dd0ad8ca6?s=80&r=pg" width="64" height="64" />

**Comment by Ben van der Stouwe on test-driving-windows-11-dev-drive-for-dotnet:**

Hi Maarten,

Thanks for the post! I was able to setup my Dev Drive using this.

I think you have a bug in your PowerShell script to move package folders. You're moving the `npm-cache*` folders with the Move-Item command but you're setting the environment variable to `npm_cache`. I believe NPM won't use the moved cached packages because of this and will resolve them in the configured directory. 

Also, the "remove all bin and obj folders" command also removed ObjectExtensions classes in my case. Changing the `bin,obj*` to `bin,obj` still removed all bin and obj folders but did not remove the ObjectExtensions classes.

And slightly off-topic, I was not able to type a comment on this page while in Firefox. It's working on Edge. 

Keep up the good work!
