### PR TITLE
Comment by Mike Towill on aspnet-core-rate-limiting-middleware

### DIFF
--- a/_data/comments/aspnet-core-rate-limiting-middleware/bcbeadfd.yml
+++ b/_data/comments/aspnet-core-rate-limiting-middleware/bcbeadfd.yml
@@ -1,0 +1,16 @@
+id: ae19a219
+date: 2024-04-16T12:44:08.1973410Z
+name: Mike Towill
+email: 
+avatar: https://secure.gravatar.com/avatar/8242a3c29143d73b73f9c7158c53cbda?s=80&r=pg
+url: 
+message: >+
+  > Here’s an example where the rate limiter options are partitioned by either the current authenticated user, or their hostname
+
+
+  >`httpContext.Request.Headers.Host.ToString()`
+
+
+  HTTP Host header is the server domain. Not the client's hostname. So this method is inadequate for unauthenticated users on a login screen, for example
+
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/8242a3c29143d73b73f9c7158c53cbda?s=80&r=pg" width="64" height="64" />

**Comment by Mike Towill on aspnet-core-rate-limiting-middleware:**

> Here’s an example where the rate limiter options are partitioned by either the current authenticated user, or their hostname

>`httpContext.Request.Headers.Host.ToString()`

HTTP Host header is the server domain. Not the client's hostname. So this method is inadequate for unauthenticated users on a login screen, for example


