### PR TITLE
Comment by 10basetom on test-driving-windows-11-dev-drive-for-dotnet

### DIFF
--- a/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/35df57d0.yml
+++ b/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/35df57d0.yml
@@ -1,0 +1,11 @@
+id: 373ffe1e
+date: 2024-12-27T06:04:41.3717374Z
+name: 10basetom
+email: 
+avatar: https://secure.gravatar.com/avatar/2f3d521daf2fca0116987e9c8354ec55?s=80&r=pg
+url: 
+message: >-
+  Note that on Windows 11, you no longer need the updated NuGet package:
+
+
+  "Note: On Windows this library is being superseded by CoW support now built into the Windows 11 24H2 release, as well as Windows Server 2025. Use of CoW is automatic for Dev Drive and ReFS volumes starting in these OS versions."


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/2f3d521daf2fca0116987e9c8354ec55?s=80&r=pg" width="64" height="64" />

**Comment by 10basetom on test-driving-windows-11-dev-drive-for-dotnet:**

Note that on Windows 11, you no longer need the updated NuGet package:

"Note: On Windows this library is being superseded by CoW support now built into the Windows 11 24H2 release, as well as Windows Server 2025. Use of CoW is automatic for Dev Drive and ReFS volumes starting in these OS versions."