### PR TITLE
Comment by OzBob on custom-bindings-with-azure-functions-dotnet-isolated-worker

### DIFF
--- a/_data/comments/custom-bindings-with-azure-functions-dotnet-isolated-worker/f26caa66.yml
+++ b/_data/comments/custom-bindings-with-azure-functions-dotnet-isolated-worker/f26caa66.yml
@@ -1,0 +1,15 @@
+id: 037278ae
+date: 2025-01-13T01:01:30.4399896Z
+name: OzBob
+email: 
+avatar: https://secure.gravatar.com/avatar/d0a182f97019de15b235587fc1960b0b?s=80&r=pg
+url: 
+message: >+
+  There is an open issue on the azure functions work about custom bindings https://github.com/Azure/azure-functions-dotnet-worker/issues/2092
+
+  I've not had much luck in making this work in .Net9 isolated with Microsoft.Azure.Functions.Worker v2 
+
+  Will you do an updated version of this post with .net9?
+
+  Have POJO's become supported? Rather than only string bindings?
+


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/d0a182f97019de15b235587fc1960b0b?s=80&r=pg" width="64" height="64" />

**Comment by OzBob on custom-bindings-with-azure-functions-dotnet-isolated-worker:**

There is an open issue on the azure functions work about custom bindings https://github.com/Azure/azure-functions-dotnet-worker/issues/2092
I've not had much luck in making this work in .Net9 isolated with Microsoft.Azure.Functions.Worker v2 
Will you do an updated version of this post with .net9?
Have POJO's become supported? Rather than only string bindings?

