### PR TITLE
Comment by Thaer Razeq on test-driving-windows-11-dev-drive-for-dotnet

### DIFF
--- a/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/76f78514.yml
+++ b/_data/comments/test-driving-windows-11-dev-drive-for-dotnet/76f78514.yml
@@ -1,0 +1,55 @@
+id: 77d7e2c1
+date: 2025-08-01T14:12:40.9663477Z
+name: Thaer Razeq
+email: 
+avatar: https://secure.gravatar.com/avatar/7efd0cfa636fa22f9a10a1479dc557eb?s=80&r=pg
+url: 
+message: >-
+  Hey, I have been using DevDrive feature for over a year, although I am programmer, I did not use it for my projects and builds. What I use it for instead is to store my Steam library in a DevDrive ReFS volume, stored in SMB share on a TrueNAS. This way, I get many benefits, Copy-on-Write (CoW) (similar to ZFS Deduplication). Great to have same games multiple times while only taking space once for most files that remained the same (speaking about game MODs). And also, while ReFS does not support compression, the VHDX file is stored in a ZFS dataset with high level of compression using ZSTD. And I remount the VHD after every reboot using task scheduler as a powershell command.
+
+
+  But for those of you that "asynchronous" scanning is turned off, check:
+
+
+  - Windows Defender ➡️ Virus & threat protection ➡️ Virus & threat protection settings (manage settings) ➡️ Dev Drive Protection (make sure it is enabled) but most importantly check under it "See Volumes"
+
+
+  In my case it showed:
+
+
+  "Virtual Steam Library X:\
+
+  Asynchronous scanning is off. Real-time protection might impact performance."
+
+
+  To fix this, I ran powershell as admin and typed this command (X is the drive letter):
+
+
+  fsutil devdrv trust X:
+
+
+  it gave me this result:
+
+
+  "The volume is in use and the change may not take effect immediately.
+
+  Please dismount the volume for the change to take effect.
+
+  Error 5: Access is denied."
+
+
+  I simply dismounted (Eject) the drive from File Explorer. And remounted the drive, I used Mount-VHD powershell command which I saved in task scheduler instead of typing the long path of IP address and path (URI).
+
+
+  Now, when I go to Windows Defender again:
+
+  - Windows Defender ➡️ Virus & threat protection ➡️ Virus & threat protection settings (manage settings) ➡️ Dev Drive Protection (make sure it is enabled) but most importantly check under it "See Volumes"
+
+
+  It lists my volume X as:
+
+
+  "Asynchronous scanning is on to reduce performance impact."
+
+
+  This is how I fixed it, I hope this helps. I just thought all this time that asynchronous scanning was on for a whole year, until I saw @Andreas comment here that it was not enabled. I double checked and indeed it was not. But I found a solution quickly using CoPilot from Windows. Who said copilot sucks, lol, it definitely beats the old days of surfing and scanning the internet for an answer.


### PR DESCRIPTION
<img src="https://secure.gravatar.com/avatar/7efd0cfa636fa22f9a10a1479dc557eb?s=80&r=pg" width="64" height="64" />

**Comment by Thaer Razeq on test-driving-windows-11-dev-drive-for-dotnet:**

Hey, I have been using DevDrive feature for over a year, although I am programmer, I did not use it for my projects and builds. What I use it for instead is to store my Steam library in a DevDrive ReFS volume, stored in SMB share on a TrueNAS. This way, I get many benefits, Copy-on-Write (CoW) (similar to ZFS Deduplication). Great to have same games multiple times while only taking space once for most files that remained the same (speaking about game MODs). And also, while ReFS does not support compression, the VHDX file is stored in a ZFS dataset with high level of compression using ZSTD. And I remount the VHD after every reboot using task scheduler as a powershell command.

But for those of you that "asynchronous" scanning is turned off, check:

- Windows Defender ➡️ Virus & threat protection ➡️ Virus & threat protection settings (manage settings) ➡️ Dev Drive Protection (make sure it is enabled) but most importantly check under it "See Volumes"

In my case it showed:

"Virtual Steam Library X:\
Asynchronous scanning is off. Real-time protection might impact performance."

To fix this, I ran powershell as admin and typed this command (X is the drive letter):

fsutil devdrv trust X:

it gave me this result:

"The volume is in use and the change may not take effect immediately.
Please dismount the volume for the change to take effect.
Error 5: Access is denied."

I simply dismounted (Eject) the drive from File Explorer. And remounted the drive, I used Mount-VHD powershell command which I saved in task scheduler instead of typing the long path of IP address and path (URI).

Now, when I go to Windows Defender again:
- Windows Defender ➡️ Virus & threat protection ➡️ Virus & threat protection settings (manage settings) ➡️ Dev Drive Protection (make sure it is enabled) but most importantly check under it "See Volumes"

It lists my volume X as:

"Asynchronous scanning is on to reduce performance impact."

This is how I fixed it, I hope this helps. I just thought all this time that asynchronous scanning was on for a whole year, until I saw @Andreas comment here that it was not enabled. I double checked and indeed it was not. But I found a solution quickly using CoPilot from Windows. Who said copilot sucks, lol, it definitely beats the old days of surfing and scanning the internet for an answer.